### PR TITLE
simplify main.ipynb function

### DIFF
--- a/python/main.ipynb
+++ b/python/main.ipynb
@@ -2,51 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "9f5a30f9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Full Dataset:\n",
-      " id neo_reference_id        name                                                    nasa_jpl_url  absolute_magnitude_h  estimated_diameter_min_km  estimated_diameter_max_km  is_potentially_hazardous_asteroid close_approach_date close_approach_date_full  relative_velocity_kph  miss_distance_km orbiting_body  is_sentry_object         ingested_at\n",
-      "  1          3745999 (2016 ES84)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3745999                20.310                   0.230438                   0.515276                                  0          2026-04-01        2026-Apr-01 17:14          122481.837524      6.518220e+07         Earth                 0 2026-04-01 23:33:49\n",
-      "  2          3802103  (2018 FK5)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3802103                28.300                   0.005815                   0.013003                                  0          2026-04-01        2026-Apr-01 21:06           36109.686403      7.889941e+06         Earth                 0 2026-04-01 23:33:49\n",
-      "  3          3802440  (2018 GA2)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3802440                23.440                   0.054520                   0.121910                                  0          2026-04-01        2026-Apr-01 13:21           65338.156215      4.652005e+07         Earth                 0 2026-04-01 23:33:49\n",
-      "  4          3840893  (2019 GC6)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3840893                26.500                   0.013322                   0.029788                                  0          2026-04-01        2026-Apr-01 08:23           48659.837994      4.153711e+07         Earth                 0 2026-04-01 23:33:49\n",
-      "  5         54134665  (2021 GN1) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54134665                26.420                   0.013821                   0.030906                                  0          2026-04-01        2026-Apr-01 22:26           49565.078284      1.395427e+07         Earth                 0 2026-04-01 23:33:49\n",
-      "  6         54143556  (2021 JR1) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54143556                23.360                   0.056566                   0.126485                                  0          2026-04-01        2026-Apr-01 07:39           49605.939450      4.804389e+07         Earth                 0 2026-04-01 23:33:49\n",
-      "  7         54265894  (2022 FF3) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54265894                27.770                   0.007423                   0.016597                                  0          2026-04-01        2026-Apr-01 09:53           50045.846680      4.145145e+07         Earth                 0 2026-04-01 23:33:49\n",
-      "  8         54496016  (2024 UT4) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54496016                27.600                   0.008027                   0.017949                                  0          2026-04-01        2026-Apr-01 10:22           22140.501989      2.367885e+07         Earth                 0 2026-04-01 23:33:49\n",
-      "  9         54606506  (2026 FL1) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54606506                25.381                   0.022303                   0.049870                                  0          2026-04-01        2026-Apr-01 00:42           29745.036746      8.571952e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 10         54606828  (2026 FM4) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54606828                25.728                   0.019009                   0.042505                                  0          2026-04-01        2026-Apr-01 17:57           35808.285728      8.628520e+06         Earth                 0 2026-04-01 23:33:49\n",
-      "Cleaned Dataset:\n",
-      " id neo_reference_id       name                                                    nasa_jpl_url  absolute_magnitude_h  estimated_diameter_min_km  estimated_diameter_max_km  is_potentially_hazardous_asteroid close_approach_date close_approach_date_full  relative_velocity_kph  miss_distance_km orbiting_body  is_sentry_object         ingested_at\n",
-      " 14         54607055 (2026 FH7) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54607055                26.804                   0.011581                   0.025896                                  0          2026-04-01        2026-Apr-01 21:51           29773.294343      7.192028e+05         Earth                 0 2026-04-01 23:33:49\n",
-      " 49         54347996 (2023 DZ2) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54347996                24.280                   0.037030                   0.082802                                  0          2026-04-04        2026-Apr-04 02:04           26061.586230      1.012422e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 31          3560131 (2011 FT9)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3560131                26.200                   0.015295                   0.034201                                  0          2026-04-07        2026-Apr-07 00:22           21137.492795      1.321170e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 57         54607052 (2026 FF7) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54607052                27.472                   0.008514                   0.019039                                  0          2026-04-04        2026-Apr-04 19:50           47046.660716      1.771463e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 36         54489663 (2024 TB7) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54489663                29.230                   0.003789                   0.008473                                  0          2026-04-07        2026-Apr-07 14:21           27085.378477      1.863694e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 21         54136202 (2021 GN6) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54136202                26.960                   0.010778                   0.024101                                  0          2026-04-06        2026-Apr-06 08:49           25375.561708      2.218034e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 77         54606736 (2026 FD4) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54606736                27.754                   0.007477                   0.016720                                  0          2026-04-02        2026-Apr-02 10:33           21556.196313      3.046750e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 80         54607105 (2026 FQ8) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54607105                25.921                   0.017392                   0.038890                                  0          2026-04-02        2026-Apr-02 02:25           29094.577840      3.083591e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 51         54606897 (2026 FG5) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54606897                25.037                   0.026131                   0.058431                                  0          2026-04-04        2026-Apr-04 03:27           89661.031738      3.296996e+06         Earth                 0 2026-04-01 23:33:49\n",
-      " 83          3840727 (2019 FQ1)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3840727                27.200                   0.009651                   0.021579                                  0          2026-04-03        2026-Apr-03 04:39           36350.170391      3.671458e+06         Earth                 0 2026-04-01 23:33:49\n",
-      "\n",
-      "Daily Summary:\n",
-      "close_approach_date  approach_count  avg_miss_distance_km  min_miss_distance_km  max_miss_distance_km  avg_relative_velocity_kph  hazardous_count\n",
-      "         2026-04-01              16          2.210138e+07          7.192028e+05          6.518220e+07               46241.522554                0\n",
-      "         2026-04-02              11          2.504201e+07          3.046750e+06          7.244203e+07               42075.715959                0\n",
-      "         2026-04-03               7          3.825497e+07          3.671458e+06          7.451122e+07               56237.234823                0\n",
-      "         2026-04-04              20          3.149228e+07          1.012422e+06          7.055080e+07               46832.952239                0\n",
-      "         2026-04-05              12          3.012480e+07          5.899224e+06          6.926201e+07               49569.533406                0\n",
-      "         2026-04-06              11          3.869098e+07          2.218034e+06          7.154895e+07               48986.956426                0\n",
-      "         2026-04-07              10          1.989720e+07          1.321170e+06          4.365076e+07               48847.103133                0\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Analyzing the cleaned data from SQL\n",
     "\n",
@@ -70,17 +29,8 @@
     "\n",
     "    return df_all, df_clean, df_daily\n",
     "\n",
-    "\n",
-    "def display_analytics():\n",
-    "    df_all, df_clean, df_daily = load_neows_data()\n",
-    "    print(\"Full Dataset:\")\n",
-    "    print(df_all.head(10).to_string(index=False))\n",
-    "    print(\"Cleaned Dataset:\")\n",
-    "    print(df_clean.head(10).to_string(index=False))\n",
-    "    print(\"\\nDaily Summary:\")\n",
-    "    print(df_daily.to_string(index=False))\n",
-    "\n",
-    "display_analytics()"
+    "# you can use these dataframe variables across all notebook files\n",
+    "df_all, df_clean, df_daily = load_neows_data()"
    ]
   }
  ],

--- a/python/q2.ipynb
+++ b/python/q2.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "57141d2b",
+   "metadata": {},
+   "source": [
+    "# Question 2\n",
+    "What factors go into making an asteroid potentially hazardous or not?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "6559f1f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " id neo_reference_id       name                                                    nasa_jpl_url  absolute_magnitude_h  estimated_diameter_min_km  estimated_diameter_max_km  is_potentially_hazardous_asteroid close_approach_date close_approach_date_full  relative_velocity_kph  miss_distance_km orbiting_body  is_sentry_object         ingested_at\n",
+      " 14         54607055 (2026 FH7) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54607055                26.804                   0.011581                   0.025896                                  0          2026-04-01        2026-Apr-01 21:51           29773.294343      7.192028e+05         Earth                 0 2026-04-01 23:33:49\n",
+      " 49         54347996 (2023 DZ2) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54347996                24.280                   0.037030                   0.082802                                  0          2026-04-04        2026-Apr-04 02:04           26061.586230      1.012422e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 31          3560131 (2011 FT9)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3560131                26.200                   0.015295                   0.034201                                  0          2026-04-07        2026-Apr-07 00:22           21137.492795      1.321170e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 57         54607052 (2026 FF7) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54607052                27.472                   0.008514                   0.019039                                  0          2026-04-04        2026-Apr-04 19:50           47046.660716      1.771463e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 36         54489663 (2024 TB7) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54489663                29.230                   0.003789                   0.008473                                  0          2026-04-07        2026-Apr-07 14:21           27085.378477      1.863694e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 21         54136202 (2021 GN6) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54136202                26.960                   0.010778                   0.024101                                  0          2026-04-06        2026-Apr-06 08:49           25375.561708      2.218034e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 77         54606736 (2026 FD4) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54606736                27.754                   0.007477                   0.016720                                  0          2026-04-02        2026-Apr-02 10:33           21556.196313      3.046750e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 80         54607105 (2026 FQ8) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54607105                25.921                   0.017392                   0.038890                                  0          2026-04-02        2026-Apr-02 02:25           29094.577840      3.083591e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 51         54606897 (2026 FG5) https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=54606897                25.037                   0.026131                   0.058431                                  0          2026-04-04        2026-Apr-04 03:27           89661.031738      3.296996e+06         Earth                 0 2026-04-01 23:33:49\n",
+      " 83          3840727 (2019 FQ1)  https://ssd.jpl.nasa.gov/tools/sbdb_lookup.html#/?sstr=3840727                27.200                   0.009651                   0.021579                                  0          2026-04-03        2026-Apr-03 04:39           36350.170391      3.671458e+06         Earth                 0 2026-04-01 23:33:49\n"
+     ]
+    }
+   ],
+   "source": [
+    "%run ./main.ipynb\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(df_clean.head(10).to_string(index=False))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv (3.13.12)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 requests 
 python-dotenv 
 sqlite-utils
+import-ipynb


### PR DESCRIPTION
Removed the function at the bottom to make the dataframe variables global in scope. That way, they can easily be accessed from other `.ipynb` files.

Also started on question 2